### PR TITLE
Remove unnecessary ternary operator in $digest definition

### DIFF
--- a/app/ActivityPub/HTTPSignature.php
+++ b/app/ActivityPub/HTTPSignature.php
@@ -8,10 +8,11 @@ use DateTime;
 class HTTPSignature {
 
   public static function sign(User &$user, $url, $body=false, $addlHeaders=[]) {
+    $digest = false;
     if($body)
       $digest = self::_digest($body);
 
-    $headers = self::_headersToSign($url, $body ? $digest : false);
+    $headers = self::_headersToSign($url, $digest);
 
     $headers = array_merge($headers, $addlHeaders);
 


### PR DESCRIPTION
I believe this makes the code cleaner (both easier to read and understand).